### PR TITLE
Do not use async for goog

### DIFF
--- a/src/goog.js
+++ b/src/goog.js
@@ -28,7 +28,7 @@ define(['async', 'propertyParser'], function (async, propertyParser) {
 
                 settings.callback = onLoad;
 
-                req(['async!'+ (document.location.protocol === 'https:'? 'https' : 'http') +'://www.google.com/jsapi'], function(){
+                req([(document.location.protocol === 'https:'? 'https' : 'http') +'://www.google.com/jsapi'], function(){
                     google.load(data.moduleName, data.version, settings);
                 });
             }


### PR DESCRIPTION
Due to google API updates, the old version of API would not work with async loading.

https://developers.google.com/chart/interactive/docs/basic_load_libs#update-library-loader-code